### PR TITLE
feat: Change API response from base64 string to PNG file

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -99,10 +99,15 @@ const server = http.createServer(async (req, res) => {
     };
 
     console.log('Generating chart');
-    const dataUrl = await chartJSNodeCanvas.renderToDataURL(configuration);
+    const dataUrl = await chartJSNodeCanvas.renderToDataURL(configuration, 'image/png');
+    const base64Image = dataUrl.replace(/^data:image\/png;base64,/, '');
+    const imageBuffer = Buffer.from(base64Image, 'base64');
     console.log('Chart generated');
-    res.writeHead(200, { 'Content-Type': 'text/plain' });
-    res.end(dataUrl);
+    res.writeHead(200, {
+      'Content-Type': 'image/png',
+      'Content-Length': imageBuffer.length,
+    });
+    res.end(imageBuffer);
   } catch (error) {
     console.error('Error in server:', error.message);
     if (error.response) {

--- a/test/test.js
+++ b/test/test.js
@@ -25,19 +25,18 @@ describe('API Tests', function () {
     server.kill();
   });
 
-  it('should return a valid data URL for a valid username', (done) => {
-    axios
-      .get('http://localhost:3001/lxlgarnett')
-      .then((response) => {
-        expect(response.status).to.equal(200);
-        expect(response.headers['content-type']).to.equal('text/plain');
-        expect(response.data).to.include('data:image/png;base64,');
-        done();
-      })
-      .catch((error) => {
-        console.error(error);
-        done(error);
-      });
+  it('should return a valid PNG image for a valid username', async () => {
+    const response = await axios.get('http://localhost:3001/lxlgarnett', {
+      responseType: 'arraybuffer',
+    });
+    expect(response.status).to.equal(200);
+    expect(response.headers['content-type']).to.equal('image/png');
+    // Check for PNG magic numbers
+    const magicNumbers = response.data.slice(0, 8);
+    const pngSignature = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    expect(Buffer.compare(Buffer.from(magicNumbers), pngSignature)).to.equal(0);
   });
 
   it('should return language statistics in JSON format, excluding forked repositories', async () => {


### PR DESCRIPTION
Modified api/index.js to return a PNG image buffer instead of a base64 string.
Updated test/test.js to reflect the new response format and verify PNG content.
