### PR TITLE
feat: Implement dark theme for chart and display percentages

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -3,10 +3,18 @@ const http = require('http');
 const { URL } = require('url');
 const axios = require('axios');
 const { ChartJSNodeCanvas } = require('chartjs-node-canvas');
+const ChartDataLabels = require('chartjs-plugin-datalabels');
 
 const width = 400;
 const height = 400;
-const chartJSNodeCanvas = new ChartJSNodeCanvas({ width, height });
+const chartJSNodeCanvas = new ChartJSNodeCanvas({
+  width,
+  height,
+  backgroundColour: '#22272e',
+  plugins: {
+    modern: [ChartDataLabels],
+  },
+});
 
 const server = http.createServer(async (req, res) => {
   console.log(`Request received for URL: ${req.url}`);
@@ -93,8 +101,31 @@ const server = http.createServer(async (req, res) => {
               '#1abc9c',
               '#34495e',
             ],
+            borderColor: '#22272e',
+            borderWidth: 1,
           },
         ],
+      },
+      options: {
+        plugins: {
+          legend: {
+            labels: {
+              color: '#ffffff',
+            },
+          },
+          datalabels: {
+            color: '#ffffff',
+            formatter: (value, ctx) => {
+              let sum = 0;
+              let dataArr = ctx.chart.data.datasets[0].data;
+              dataArr.map((data) => {
+                sum += data;
+              });
+              let percentage = ((value * 100) / sum).toFixed(1) + '%';
+              return percentage;
+            },
+          },
+        },
       },
     };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.13.2",
         "chart.js": "^4.5.1",
         "chartjs-node-canvas": "^5.0.0",
+        "chartjs-plugin-datalabels": "^2.2.0",
         "dotenv": "^17.2.3"
       },
       "devDependencies": {
@@ -291,6 +292,15 @@
       },
       "peerDependencies": {
         "chart.js": "^4.4.8"
+      }
+    },
+    "node_modules/chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "axios": "^1.13.2",
     "chart.js": "^4.5.1",
     "chartjs-node-canvas": "^5.0.0",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "dotenv": "^17.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Configured chart with a dark background, light legend labels, and borders
for a dark theme aesthetic. Integrated 'chartjs-plugin-datalabels' to
display percentage values directly on the pie chart segments.
